### PR TITLE
group composite and general debugging improvements

### DIFF
--- a/Core/BehaviorTree.js
+++ b/Core/BehaviorTree.js
@@ -95,6 +95,76 @@ export class GroupComposite extends Composite {
   }
 
   /**
+   * Inserts a child node at a specific index in the children list.
+   * @param {Composite} child - The child node to insert.
+   * @param {number} index - The index at which to insert (clamped to valid range).
+   */
+  insertChild(child, index) {
+    const clampedIndex = Math.max(0, Math.min(index, this.children.length));
+    this.children.splice(clampedIndex, 0, child);
+  }
+
+  /**
+   * Removes a child node from the children list.
+   * @param {Composite} child - The child node to remove.
+   * @returns {boolean} True if the child was removed, false if not found.
+   */
+  removeChild(child) {
+    const index = this.children.indexOf(child);
+    if (index !== -1) {
+      this.children.splice(index, 1);
+      if (index <= this.activeChildIndex) {
+        this.activeChildIndex = Math.max(-1, this.activeChildIndex - 1);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Removes a child node at a specific index from the children list.
+   * @param {number} index - The index of the child to remove.
+   * @returns {boolean} True if a child was removed, false if index was invalid.
+   */
+  removeChildAt(index) {
+    if (index >= 0 && index < this.children.length) {
+      this.children.splice(index, 1);
+      if (index <= this.activeChildIndex) {
+        this.activeChildIndex = Math.max(-1, this.activeChildIndex - 1);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Removes all child nodes that match a condition.
+   * @param {function(Composite): boolean} predicate - Function that returns true for children to remove.
+   * @returns {number} The number of children removed.
+   */
+  removeChildrenByCondition(predicate) {
+    let removedCount = 0;
+    for (let i = this.children.length - 1; i >= 0; i--) {
+      if (predicate(this.children[i])) {
+        this.children.splice(i, 1);
+        if (i <= this.activeChildIndex) {
+          this.activeChildIndex = Math.max(-1, this.activeChildIndex - 1);
+        }
+        removedCount++;
+      }
+    }
+    return removedCount;
+  }
+
+  /**
+   * Removes all child nodes from the children list.
+   */
+  clearChildren() {
+    this.children.length = 0;
+    this.activeChildIndex = -1;
+  }
+
+  /**
    * Resets the active child index.
    */
   reset() {

--- a/Debug/DebugWindow.js
+++ b/Debug/DebugWindow.js
@@ -2,10 +2,12 @@ import nuclear from '@/nuclear';
 import objMgr from '../Core/ObjectManager';
 import Settings from "../Core/Settings";
 import { renderBehaviorTree } from './BehaviorTreeDebug';
+import PerfMgr from './PerfMgr';
 
 class DebugWindow {
   constructor() {
     this.show = new imgui.MutableVariable(false);
+    this.displayPerfMgr = new imgui.MutableVariable(false);
     this.selected = null;
     this.selectedSpell = null;
   }
@@ -29,6 +31,10 @@ class DebugWindow {
     if (!imgui.begin("Debug", open)) {
       imgui.end();
       return;
+    }
+
+    if (imgui.checkbox("Display Performance", this.displayPerfMgr)) {
+      PerfMgr.enabled = this.displayPerfMgr.value;
     }
 
     if (imgui.beginTabBar("debugTabs")) {

--- a/Debug/PerfMgr.js
+++ b/Debug/PerfMgr.js
@@ -1,9 +1,9 @@
 class PerfMgr {
-  /** @type {Map<string, object>} */
-  renderTimes;
-
   constructor() {
+    /** @type {Map<string, object>} */
     this.renderTimes = new Map();
+    /** @type {Boolean} */
+    this.enabled = false;
   }
 
   begin(name) {
@@ -35,6 +35,9 @@ class PerfMgr {
   }
 
   render() {
+    if (!this.enabled) {
+      return;
+    }
     let perfWindowFlags = imgui.WindowFlags.None;
     perfWindowFlags |= imgui.WindowFlags.NoBackground;
     perfWindowFlags |= imgui.WindowFlags.NoCollapse;

--- a/nuclear.js
+++ b/nuclear.js
@@ -2,6 +2,7 @@ import { BehaviorContext } from "./Core/Behavior";
 import BehaviorBuilder from "./Core/BehaviorBuilder";
 import objMgr, { me } from "./Core/ObjectManager";
 import { flagsComponents } from "./Core/Util";
+import colors from "./Enums/Colors";
 import { defaultHealTargeting } from "./Targeting/HealTargeting";
 import { defaultCombatTargeting } from "./Targeting/CombatTargeting";
 import commandListener from '@/Core/CommandListener'
@@ -20,7 +21,10 @@ class Nuclear extends wow.EventListener {
     if (!this.gameReady()) {
       return;
     }
-    if (this.error) { return; }
+    if (this.error) {
+      imgui.getBackgroundDrawList()?.addText("ERROR", { x: 10, y: 10 }, colors.red);
+      return;
+    }
 
     try {
       defaultHealTargeting?.update();


### PR DESCRIPTION
Added more control of group composite children like inserting, removing and clearing.

Performance manager only draws if enabled in the debug window.

Display a text in the top-left corner if an error occurs so it's quick to see when it stops.