### PR TITLE
Add rejiko/ author folder with 6 rotation profiles

### DIFF
--- a/Behaviors/rejiko/InitialDruid.js
+++ b/Behaviors/rejiko/InitialDruid.js
@@ -1,0 +1,69 @@
+import { Behavior, BehaviorContext } from "@/Core/Behavior";
+import * as bt from '@/Core/BehaviorTree';
+import Specialization from '@/Enums/Specialization';
+import common from '@/Core/Common';
+import spell from "@/Core/Spell";
+import { me } from "@/Core/ObjectManager";
+import { defaultCombatTargeting as combat } from "@/Targeting/CombatTargeting";
+import { defaultHealTargeting as heal } from "@/Targeting/HealTargeting";
+import Settings from '@/Core/Settings';
+
+export class DruidInitialBehavior extends Behavior {
+  name = "[Rejiko] Initial Druid";
+  context = BehaviorContext.Any;
+  specialization = Specialization.Druid.Initial;
+  static settings = [
+    {
+      header: "Defense",
+      options: [
+        { type: "slider", uid: "DruidInitialBarkskinHP", text: "Barkskin (HP %)", min: 1, max: 100, default: 60 },
+        { type: "slider", uid: "DruidInitialRegrowthHP", text: "Regrowth (HP %)", min: 1, max: 100, default: 70 },
+      ]
+    },
+    {
+      header: "DPS",
+      options: [
+        { type: "slider", uid: "DruidInitialMoonfireRefreshMs", text: "Moonfire refresh window (ms)", min: 0, max: 3000, default: 1500 },
+      ]
+    }
+  ];
+
+  build() {
+    return new bt.Selector(
+      common.waitForNotMounted(),
+      common.waitForNotSitting(),
+      common.waitForCastOrChannel(),
+      spell.cast("Barkskin", on => me, req => me.pctHealth <= Settings.DruidInitialBarkskinHP),
+      new bt.Decorator(
+        ret => !spell.isGlobalCooldown(),
+        new bt.Selector(
+          spell.cast("Regrowth", on => this.regrowthTarget()),
+          spell.cast("Mark of the Wild", on => this.motwTarget()),
+          common.waitForTarget(),
+          common.waitForFacing(),
+          common.ensureAutoAttack(),
+          spell.cast("Moonfire", on => this.moonfireTarget()),
+          spell.cast("Wrath", on => combat.bestTarget)
+        )
+      )
+    );
+  }
+
+  regrowthTarget() {
+    const t = heal.getPriorityTarget();
+    if (t && t.predictedHealthPercent <= Settings.DruidInitialRegrowthHP) return t;
+    return null;
+  }
+
+  motwTarget() {
+    return heal.friends.All.find(u => !u.hasAuraByMe("Mark of the Wild")) || null;
+  }
+
+  moonfireTarget() {
+    const t = me.target;
+    if (!t) return null;
+    const dot = t.getAuraByMe("Moonfire");
+    if (!dot || dot.remaining <= Settings.DruidInitialMoonfireRefreshMs) return t;
+    return null;
+  }
+}

--- a/Behaviors/rejiko/InitialRogue.js
+++ b/Behaviors/rejiko/InitialRogue.js
@@ -1,0 +1,69 @@
+import { Behavior, BehaviorContext } from "@/Core/Behavior";
+import * as bt from '@/Core/BehaviorTree';
+import Specialization from '@/Enums/Specialization';
+import common from '@/Core/Common';
+import spell from "@/Core/Spell";
+import { me } from "@/Core/ObjectManager";
+import { defaultCombatTargeting as combat } from "@/Targeting/CombatTargeting";
+import { PowerType } from "@/Enums/PowerType";
+import Settings from '@/Core/Settings';
+
+export class RogueInitialBehavior extends Behavior {
+  name = "[Rejiko] Initial Rogue";
+  context = BehaviorContext.Any;
+  specialization = Specialization.Rogue.Initial;
+  static settings = [
+    {
+      header: "Finishers",
+      options: [
+        { type: "checkbox", uid: "RogueInitialUseEviscerate", text: "Use Eviscerate", default: true },
+        { type: "slider", uid: "RogueInitialEviscerateComboPoints", text: "Eviscerate combo points", min: 1, max: 5, default: 5 },
+      ]
+    },
+    {
+      header: "Defensives",
+      options: [
+        { type: "checkbox", uid: "RogueInitialUseCrimsonVial", text: "Use Crimson Vial", default: true },
+        { type: "slider", uid: "RogueInitialCrimsonVialHP", text: "Crimson Vial (HP %)", min: 1, max: 100, default: 70 },
+      ]
+    }
+  ];
+
+  build() {
+    return new bt.Selector(
+      common.waitForNotMounted(),
+      common.waitForNotSitting(),
+      common.waitForCastOrChannel(),
+      spell.interrupt("Kick"),
+      spell.cast("Crimson Vial", on => me, req =>
+        Settings.RogueInitialUseCrimsonVial && me.pctHealth <= Settings.RogueInitialCrimsonVialHP
+      ),
+      new bt.Decorator(
+        ret => !spell.isGlobalCooldown(),
+        new bt.Selector(
+          spell.cast("Instant Poison", on => me, req => !me.inCombat() && !me.hasVisibleAura("Instant Poison")),
+          spell.cast("Stealth", on => me, req => !me.inCombat() && !me.hasVisibleAura("Stealth")),
+          common.waitForTarget(),
+          common.waitForFacing(),
+          new bt.Decorator(
+            () => !me.hasVisibleAura("Stealth"),
+            common.ensureAutoAttack()
+          ),
+          spell.cast("Cheap Shot", on => combat.bestTarget, req => me.hasVisibleAura("Stealth")),
+          spell.cast("Slice and Dice", on => me, req => {
+            if (me.hasVisibleAura("Stealth")) return false;
+            if (me.powerByType(PowerType.ComboPoints) < 1) return false;
+            const sd = me.getAura("Slice and Dice");
+            return !sd || sd.remaining <= sd.duration * 0.3;
+          }),
+          spell.cast("Eviscerate", on => combat.bestTarget, req =>
+            !me.hasVisibleAura("Stealth") &&
+            Settings.RogueInitialUseEviscerate &&
+            me.powerByType(PowerType.ComboPoints) >= Settings.RogueInitialEviscerateComboPoints
+          ),
+          spell.cast("Sinister Strike", on => combat.bestTarget, req => !me.hasVisibleAura("Stealth"))
+        )
+      )
+    );
+  }
+}

--- a/Behaviors/rejiko/InitialShaman.js
+++ b/Behaviors/rejiko/InitialShaman.js
@@ -1,0 +1,74 @@
+import { Behavior, BehaviorContext } from "@/Core/Behavior";
+import * as bt from '@/Core/BehaviorTree';
+import Specialization from '@/Enums/Specialization';
+import common from '@/Core/Common';
+import spell from "@/Core/Spell";
+import { me } from "@/Core/ObjectManager";
+import { defaultCombatTargeting as combat } from "@/Targeting/CombatTargeting";
+import { defaultHealTargeting as heal } from "@/Targeting/HealTargeting";
+import Settings from '@/Core/Settings';
+
+export class ShamanInitialBehavior extends Behavior {
+  name = "[Rejiko] Initial Shaman";
+  context = BehaviorContext.Any;
+  specialization = Specialization.Shaman.Initial;
+  static settings = [
+    {
+      header: "Defense",
+      options: [
+        { type: "slider", uid: "ShamanInitialHealingSurgeHP", text: "Healing Surge (HP %)", min: 1, max: 100, default: 60 },
+      ]
+    },
+    {
+      header: "DPS",
+      options: [
+        { type: "checkbox", uid: "ShamanInitialUsePrimalStrike", text: "Use Primal Strike (melee)", default: false },
+      ]
+    }
+  ];
+
+  build() {
+    return new bt.Selector(
+      common.waitForNotMounted(),
+      common.waitForNotSitting(),
+      spell.cast("Lightning Shield", on => me, req =>
+        !me.hasAuraByMe("Lightning Shield") && !me.hasAuraByMe("Ghost Wolf")
+      ),
+      common.waitForCastOrChannel(),
+      new bt.Decorator(
+        ret => !spell.isGlobalCooldown(),
+        new bt.Selector(
+          spell.cast("Healing Surge", on => this.healingSurgeTarget()),
+          spell.cast("Ghost Wolf", on => me, req =>
+            !me.inCombat() && me.isMoving() && !me.hasAuraByMe("Ghost Wolf")
+          ),
+          common.waitForTarget(),
+          common.waitForFacing(),
+          common.ensureAutoAttack(),
+          spell.cast("Flame Shock", on => this.flameShockTarget()),
+          spell.cast("Primal Strike", on => combat.bestTarget, req => {
+            if (!Settings.ShamanInitialUsePrimalStrike) return false;
+            if (!me.isMoving()) return false;
+            const t = combat.bestTarget;
+            return t && me.isWithinMeleeRange(t);
+          }),
+          spell.cast("Lightning Bolt", on => combat.bestTarget)
+        )
+      )
+    );
+  }
+
+  healingSurgeTarget() {
+    const t = heal.getPriorityTarget();
+    if (t && t.predictedHealthPercent <= Settings.ShamanInitialHealingSurgeHP) return t;
+    return null;
+  }
+
+  flameShockTarget() {
+    const t = combat.bestTarget;
+    if (!t) return null;
+    const fs = t.getAuraByMe("Flame Shock");
+    if (!fs || fs.remaining <= 5400) return t;
+    return null;
+  }
+}

--- a/Behaviors/rejiko/OutlawRogue.js
+++ b/Behaviors/rejiko/OutlawRogue.js
@@ -1,0 +1,154 @@
+import { Behavior, BehaviorContext } from "@/Core/Behavior";
+import * as bt from '@/Core/BehaviorTree';
+import Specialization from '@/Enums/Specialization';
+import common from '@/Core/Common';
+import spell from "@/Core/Spell";
+import { me } from "@/Core/ObjectManager";
+import { defaultCombatTargeting as combat } from "@/Targeting/CombatTargeting";
+import { PowerType } from "@/Enums/PowerType";
+import { WoWDispelType, WoWAuraFlags } from "@/Enums/Auras";
+import { Classification } from "@/Enums/UnitEnums";
+import Settings from '@/Core/Settings';
+
+const rtbBuffs = ["Broadside", "Buried Treasure", "Grand Melee", "Ruthless Precision", "Skull and Crossbones", "True Bearing"];
+
+export class RogueOutlawBehavior extends Behavior {
+  name = "[Rejiko] Outlaw Rogue";
+  context = BehaviorContext.Any;
+  specialization = Specialization.Rogue.Combat;
+  static settings = [
+    {
+      header: "Finishers",
+      options: [
+        { type: "checkbox", uid: "RogueOutlawUseEviscerate", text: "Use Dispatch", default: true },
+        { type: "slider", uid: "RogueOutlawEviscerateComboPoints", text: "Finisher combo points (Dispatch / BtE)", min: 1, max: 6, default: 6 },
+      ]
+    },
+    {
+      header: "Cooldowns",
+      options: [
+        { type: "checkbox", uid: "RogueOutlawUseAdrenalineRush", text: "Use Adrenaline Rush", default: true },
+        { type: "checkbox", uid: "RogueOutlawUseTricksOfTheTrade", text: "Use Tricks of the Trade (tank)", default: true },
+      ]
+    },
+    {
+      header: "AoE",
+      options: [
+        { type: "checkbox", uid: "RogueOutlawUseBladeFlurry", text: "Use Blade Flurry", default: true },
+        { type: "slider", uid: "RogueOutlawBladeFlurryTargets", text: "Blade Flurry min targets", min: 2, max: 5, default: 2 },
+      ]
+    },
+    {
+      header: "Utility",
+      options: [
+        { type: "checkbox", uid: "RogueOutlawAutoStealth", text: "Auto-Stealth out of combat", default: true },
+      ]
+    },
+    {
+      header: "Defensives",
+      options: [
+        { type: "checkbox", uid: "RogueOutlawUseCrimsonVial", text: "Use Crimson Vial", default: true },
+        { type: "slider", uid: "RogueOutlawCrimsonVialHP", text: "Crimson Vial (HP %)", min: 1, max: 100, default: 70 },
+        { type: "checkbox", uid: "RogueOutlawUseCloakOfShadows", text: "Use Cloak of Shadows", default: true },
+        { type: "checkbox", uid: "RogueOutlawUseEvasion", text: "Use Evasion (tanking 3+ or boss)", default: true },
+      ]
+    }
+  ];
+
+  build() {
+    return new bt.Selector(
+      common.waitForNotMounted(),
+      common.waitForNotSitting(),
+      common.waitForCastOrChannel(),
+      spell.interrupt("Kick"),
+      spell.cast("Crimson Vial", on => me, req =>
+        Settings.RogueOutlawUseCrimsonVial && me.pctHealth <= Settings.RogueOutlawCrimsonVialHP
+      ),
+      spell.cast("Cloak of Shadows", on => me, req =>
+        Settings.RogueOutlawUseCloakOfShadows &&
+        !me.hasVisibleAura("Stealth") &&
+        me.auras.some(a =>
+          a.dispelType === WoWDispelType.Magic &&
+          (a.flags & WoWAuraFlags.Negative)
+        )
+      ),
+      spell.cast("Evasion", on => me, req => {
+        if (!Settings.RogueOutlawUseEvasion) return false;
+        if (me.hasVisibleAura("Evasion")) return false;
+        const tankedInMelee = combat.targets.filter(t => t.isTanking() && me.isWithinMeleeRange(t));
+        if (tankedInMelee.length >= 3) return true;
+        return tankedInMelee.some(t => t.classification === Classification.Boss);
+      }),
+      new bt.Decorator(
+        ret => !spell.isGlobalCooldown(),
+        new bt.Selector(
+          spell.cast("Instant Poison", on => me, req => !me.inCombat() && !me.hasVisibleAura("Instant Poison")),
+          spell.cast("Stealth", on => me, req =>
+            Settings.RogueOutlawAutoStealth &&
+            !me.inCombat() &&
+            !me.hasVisibleAura("Stealth")
+          ),
+          common.waitForTarget(),
+          common.waitForFacing(),
+          new bt.Decorator(
+            () => !me.hasVisibleAura("Stealth"),
+            common.ensureAutoAttack()
+          ),
+          spell.cast("Tricks of the Trade", on => {
+            const tank = me.currentParty?.members.find(m => m.isTank())?.guid.toUnit();
+            return tank && !tank.deadOrGhost ? tank : null;
+          }, req => Settings.RogueOutlawUseTricksOfTheTrade && me.inCombat()),
+          spell.cast("Ambush", on => combat.bestTarget, req =>
+            me.hasVisibleAura("Stealth") ||
+            me.hasAura("Audacity") ||
+            me.hasAura("Subterfuge")
+          ),
+          spell.cast("Roll the Bones", on => me, req => {
+            if (me.hasVisibleAura("Stealth")) return false;
+            if (!combat.targets.some(t => me.isWithinMeleeRange(t))) return false;
+            if (me.hasAura("Loaded Dice")) return true;
+            return rtbBuffs.every(b => !me.hasAura(b));
+          }),
+          spell.cast("Adrenaline Rush", on => me, req =>
+            Settings.RogueOutlawUseAdrenalineRush &&
+            !me.hasVisibleAura("Stealth") &&
+            !me.hasVisibleAura("Adrenaline Rush") &&
+            combat.targets.some(t => me.isWithinMeleeRange(t))
+          ),
+          spell.cast("Blade Rush", on => combat.bestTarget, req =>
+            !me.hasVisibleAura("Stealth") &&
+            me.powerByType(PowerType.ComboPoints) <= 5
+          ),
+          spell.cast("Blade Flurry", on => me, req =>
+            Settings.RogueOutlawUseBladeFlurry &&
+            !me.hasVisibleAura("Stealth") &&
+            !me.hasVisibleAura("Blade Flurry") &&
+            combat.targets.filter(t => me.isWithinMeleeRange(t)).length >= Settings.RogueOutlawBladeFlurryTargets
+          ),
+          spell.cast("Slice and Dice", on => me, req => {
+            if (me.hasVisibleAura("Stealth")) return false;
+            if (me.powerByType(PowerType.ComboPoints) < 1) return false;
+            const sd = me.getAura("Slice and Dice");
+            return !sd || sd.remaining <= sd.duration * 0.3;
+          }),
+          spell.cast("Between the Eyes", on => combat.bestTarget, req =>
+            !me.hasVisibleAura("Stealth") &&
+            me.powerByType(PowerType.ComboPoints) >= Settings.RogueOutlawEviscerateComboPoints
+          ),
+          spell.cast("Dispatch", on => combat.bestTarget, req =>
+            !me.hasVisibleAura("Stealth") &&
+            Settings.RogueOutlawUseEviscerate &&
+            me.powerByType(PowerType.ComboPoints) >= Settings.RogueOutlawEviscerateComboPoints
+          ),
+          spell.cast("Pistol Shot", on => combat.bestTarget, req =>
+            !me.hasVisibleAura("Stealth") &&
+            me.hasVisibleAura("Opportunity") &&
+            me.powerByType(PowerType.ComboPoints) <= 3
+          ),
+          spell.cast("Shiv", on => combat.bestTarget, req => !me.hasVisibleAura("Stealth")),
+          spell.cast("Sinister Strike", on => combat.bestTarget, req => !me.hasVisibleAura("Stealth"))
+        )
+      )
+    );
+  }
+}

--- a/Behaviors/rejiko/RestorationDruid.js
+++ b/Behaviors/rejiko/RestorationDruid.js
@@ -1,0 +1,197 @@
+import { Behavior, BehaviorContext } from "@/Core/Behavior";
+import * as bt from '@/Core/BehaviorTree';
+import Specialization from '@/Enums/Specialization';
+import common from '@/Core/Common';
+import spell from "@/Core/Spell";
+import objMgr, { me } from "@/Core/ObjectManager";
+import { defaultCombatTargeting as combat } from "@/Targeting/CombatTargeting";
+import { defaultHealTargeting as heal } from "@/Targeting/HealTargeting";
+import { DispelPriority } from "@/Data/Dispels";
+import { WoWDispelType } from "@/Enums/Auras";
+import Settings from '@/Core/Settings';
+
+export class DruidRestorationBehavior extends Behavior {
+  name = "[Rejiko] Restoration Druid";
+  context = BehaviorContext.Any;
+  specialization = Specialization.Druid.Restoration;
+  static settings = [
+    {
+      header: "Defense",
+      options: [
+        { type: "slider", uid: "DruidRestoBarkskinHP", text: "Barkskin (HP %)", min: 1, max: 100, default: 60 },
+      ]
+    },
+    {
+      header: "Healing",
+      options: [
+        { type: "slider", uid: "DruidRestoNaturesSwiftnessHP", text: "Nature's Swiftness (HP %)", min: 1, max: 100, default: 40 },
+        { type: "slider", uid: "DruidRestoSwiftmendHP", text: "Swiftmend (HP %)", min: 1, max: 100, default: 60 },
+        { type: "slider", uid: "DruidRestoWildGrowthTargets", text: "Wild Growth min targets", min: 2, max: 6, default: 3 },
+        { type: "slider", uid: "DruidRestoWildGrowthHP", text: "Wild Growth count below (HP %)", min: 1, max: 100, default: 90 },
+        { type: "checkbox", uid: "DruidRestoUseEfflorescence", text: "Use Efflorescence (on tank)", default: true },
+        { type: "slider", uid: "DruidRestoRejuvenationHP", text: "Rejuvenation (HP %)", min: 1, max: 100, default: 85 },
+        { type: "slider", uid: "DruidRestoRegrowthHP", text: "Regrowth (HP %)", min: 1, max: 100, default: 65 },
+        { type: "checkbox", uid: "DruidRestoRebirth", text: "Auto-rez dead allies (Rebirth in combat, Revive out)", default: true },
+      ]
+    },
+    {
+      header: "Filler",
+      options: [
+        { type: "checkbox", uid: "DruidRestoDPSFiller", text: "DPS when nobody needs healing", default: true },
+        { type: "slider", uid: "DruidRestoDPSStopHP", text: "Stop DPS if anyone below (HP %)", min: 1, max: 100, default: 95 },
+      ]
+    }
+  ];
+
+  build() {
+    return new bt.Selector(
+      common.waitForNotMounted(),
+      common.waitForNotSitting(),
+      common.waitForCastOrChannel(),
+      spell.cast("Barkskin", on => me, req => me.pctHealth <= Settings.DruidRestoBarkskinHP),
+      spell.cast("Nature's Swiftness", on => me, req => {
+        if (me.hasAuraByMe("Nature's Swiftness")) return false;
+        const t = heal.getPriorityTarget();
+        return t && t.predictedHealthPercent <= Settings.DruidRestoNaturesSwiftnessHP;
+      }),
+      new bt.Decorator(
+        ret => !spell.isGlobalCooldown(),
+        new bt.Selector(
+          spell.dispel("Nature's Cure", true, DispelPriority.Low, true,
+            WoWDispelType.Magic, WoWDispelType.Curse, WoWDispelType.Poison),
+          spell.cast("Rebirth", on => me.inCombat() ? this.deadAllyInRange() : null),
+          spell.cast("Revive", on => !me.inCombat() ? this.deadAllyInRange() : null),
+          spell.cast("Swiftmend", on => this.swiftmendTarget()),
+          this.castEfflorescence(),
+          spell.cast("Wild Growth", on => heal.getPriorityTarget(), req => this.wildGrowthReady()),
+          spell.cast("Lifebloom", on => this.lifebloomTarget()),
+          spell.cast("Rejuvenation", on => this.rejuvenationTarget()),
+          spell.cast("Regrowth", on => this.regrowthTarget()),
+          spell.cast("Mark of the Wild", on => this.motwTarget()),
+          this.fillerDPS()
+        )
+      )
+    );
+  }
+
+  swiftmendTarget() {
+    for (const u of heal.priorityList) {
+      if (u.predictedHealthPercent <= Settings.DruidRestoSwiftmendHP &&
+          (u.hasAuraByMe("Rejuvenation") || u.hasAuraByMe("Regrowth"))) {
+        return u;
+      }
+    }
+    return null;
+  }
+
+  efflorescenceTarget() {
+    if (!Settings.DruidRestoUseEfflorescence) return null;
+    if (!me.inCombat()) return null;
+    if (wow.frameTime - this.lastEfflorescenceTime < 1500) return null;
+
+    for (const tank of heal.friends.Tanks) {
+      if (tank.deadOrGhost || me.distanceTo(tank) > 40 || tank.isMoving()) continue;
+      if (!combat.targets.some(m => tank.isWithinMeleeRange(m))) continue;
+
+      if (wow.frameTime - this.lastEfflorescenceTime < 30000 && this.lastEfflorescencePos) {
+        const dx = tank.position.x - this.lastEfflorescencePos.x;
+        const dy = tank.position.y - this.lastEfflorescencePos.y;
+        if (dx * dx + dy * dy <= 100) continue;
+      }
+
+      return tank;
+    }
+    return null;
+  }
+
+  castEfflorescence() {
+    return new bt.Action(() => {
+      const tank = this.efflorescenceTarget();
+      if (!tank) return bt.Status.Failure;
+
+      const eff = spell.getSpell("Efflorescence");
+      if (!eff || !spell.canCast(eff, tank, {})) return bt.Status.Failure;
+
+      this.lastEfflorescencePos = { x: tank.position.x, y: tank.position.y };
+      this.lastEfflorescenceTime = wow.frameTime;
+      eff.cast(tank.position);
+      return bt.Status.Success;
+    });
+  }
+
+  wildGrowthReady() {
+    let count = 0;
+    for (const u of heal.priorityList) {
+      if (u.predictedHealthPercent < Settings.DruidRestoWildGrowthHP && me.distanceTo(u) <= 30) {
+        count++;
+        if (count >= Settings.DruidRestoWildGrowthTargets) return true;
+      }
+    }
+    return false;
+  }
+
+  lifebloomTarget() {
+    for (const tank of heal.friends.Tanks) {
+      const lb = tank.getAuraByMe("Lifebloom");
+      if (!lb || lb.remaining <= 4500) return tank;
+    }
+    return null;
+  }
+
+  rejuvenationTarget() {
+    for (const u of heal.priorityList) {
+      if (u.predictedHealthPercent <= Settings.DruidRestoRejuvenationHP &&
+          !u.hasAuraByMe("Rejuvenation")) {
+        return u;
+      }
+    }
+    return null;
+  }
+
+  regrowthTarget() {
+    const t = heal.getPriorityTarget();
+    if (t && t.predictedHealthPercent <= Settings.DruidRestoRegrowthHP) return t;
+    return null;
+  }
+
+  motwTarget() {
+    return heal.friends.All.find(u => !u.hasAuraByMe("Mark of the Wild")) || null;
+  }
+
+  deadAllyInRange() {
+    if (!Settings.DruidRestoRebirth) return null;
+    const party = me.currentParty;
+    if (!party) return null;
+    for (const pm of party.members) {
+      const u = objMgr.findObject(pm.guid);
+      if (u && u.deadOrGhost && me.distanceTo(u) <= 40) return u;
+    }
+    return null;
+  }
+
+  fillerDPS() {
+    return new bt.Decorator(
+      () => {
+        if (!Settings.DruidRestoDPSFiller) return false;
+        if (!combat.bestTarget) return false;
+        for (const u of heal.priorityList) {
+          if (u.predictedHealthPercent < Settings.DruidRestoDPSStopHP) return false;
+        }
+        return true;
+      },
+      new bt.Selector(
+        common.waitForFacing(),
+        spell.cast("Moonfire", on => this.moonfireTarget()),
+        spell.cast("Wrath", on => combat.bestTarget)
+      )
+    );
+  }
+
+  moonfireTarget() {
+    const t = me.target;
+    if (!t) return null;
+    const dot = t.getAuraByMe("Moonfire");
+    if (!dot || dot.remaining <= 1500) return t;
+    return null;
+  }
+}

--- a/Behaviors/rejiko/RestorationShaman.js
+++ b/Behaviors/rejiko/RestorationShaman.js
@@ -1,0 +1,161 @@
+import { Behavior, BehaviorContext } from "@/Core/Behavior";
+import * as bt from '@/Core/BehaviorTree';
+import Specialization from '@/Enums/Specialization';
+import common from '@/Core/Common';
+import spell from "@/Core/Spell";
+import objMgr, { me } from "@/Core/ObjectManager";
+import { defaultCombatTargeting as combat } from "@/Targeting/CombatTargeting";
+import { defaultHealTargeting as heal } from "@/Targeting/HealTargeting";
+import Settings from '@/Core/Settings';
+
+export class ShamanRestorationBehavior extends Behavior {
+  name = "[Rejiko] Restoration Shaman";
+  context = BehaviorContext.Any;
+  specialization = Specialization.Shaman.Restoration;
+  static settings = [
+    {
+      header: "Healing",
+      options: [
+        { type: "slider", uid: "ShamanRestoRiptideHP", text: "Riptide (HP %)", min: 1, max: 100, default: 85 },
+        { type: "slider", uid: "ShamanRestoHealingWaveHP", text: "Healing Wave (HP %)", min: 1, max: 100, default: 70 },
+        { type: "slider", uid: "ShamanRestoChainHealHP", text: "Chain Heal count below (HP %)", min: 1, max: 100, default: 80 },
+        { type: "slider", uid: "ShamanRestoChainHealTargets", text: "Chain Heal min targets", min: 2, max: 5, default: 3 },
+        { type: "checkbox", uid: "ShamanRestoEarthShield", text: "Earth Shield on tank", default: true },
+        { type: "checkbox", uid: "ShamanRestoHealingStreamTotem", text: "Healing Stream Totem (in combat)", default: true },
+        { type: "checkbox", uid: "ShamanRestoAncestralVision", text: "Mass rez (Ancestral Vision) out of combat", default: true },
+      ]
+    },
+    {
+      header: "Filler",
+      options: [
+        { type: "checkbox", uid: "ShamanRestoDPSFiller", text: "DPS when nobody needs healing", default: true },
+        { type: "slider", uid: "ShamanRestoDPSStopHP", text: "Stop DPS if anyone below (HP %)", min: 1, max: 100, default: 95 },
+      ]
+    }
+  ];
+
+  build() {
+    return new bt.Selector(
+      common.waitForNotMounted(),
+      common.waitForNotSitting(),
+      spell.cast("Water Shield", on => me, req =>
+        !me.hasAuraByMe("Water Shield") && !me.hasAuraByMe("Ghost Wolf")
+      ),
+      common.waitForCastOrChannel(),
+      new bt.Decorator(
+        ret => !spell.isGlobalCooldown(),
+        new bt.Selector(
+          spell.cast("Ancestral Vision", on => me, req => this.shouldMassRez()),
+          spell.cast("Earth Shield", on => this.earthShieldTarget()),
+          spell.cast("Healing Stream Totem", on => me, req => this.shouldDropHealingStream()),
+          spell.cast("Riptide", on => this.riptideTarget()),
+          spell.cast("Chain Heal", on => this.chainHealTarget()),
+          spell.cast("Healing Wave", on => this.healingWaveTarget()),
+          spell.cast("Ghost Wolf", on => me, req => this.shouldGhostWolf()),
+          this.fillerDPS()
+        )
+      )
+    );
+  }
+
+  earthShieldTarget() {
+    if (!Settings.ShamanRestoEarthShield) return null;
+    for (const tank of heal.friends.Tanks) {
+      if (tank.deadOrGhost || me.distanceTo(tank) > 40) continue;
+      if (!tank.hasAuraByMe("Earth Shield")) return tank;
+    }
+    return null;
+  }
+
+  shouldDropHealingStream() {
+    if (!Settings.ShamanRestoHealingStreamTotem) return false;
+    if (!me.inCombat()) return false;
+    if (this.isTotemActive("Healing Stream Totem")) return false;
+    return combat.targets.some(t => me.distanceTo(t) <= 40);
+  }
+
+  isTotemActive(name) {
+    if (!wow.GameUI.totemInfo) return false;
+    for (let i = 1; i <= 6; i++) {
+      const info = wow.GameUI.totemInfo[i];
+      if (info && info.name === name) return true;
+    }
+    return false;
+  }
+
+  shouldGhostWolf() {
+    if (me.inCombat()) return false;
+    if (!me.isMoving()) return false;
+    if (me.hasAuraByMe("Ghost Wolf")) return false;
+    for (const u of heal.priorityList) {
+      if (me.distanceTo(u) <= 40 && u.predictedHealthPercent < Settings.ShamanRestoDPSStopHP) return false;
+    }
+    return true;
+  }
+
+  shouldMassRez() {
+    if (!Settings.ShamanRestoAncestralVision) return false;
+    if (me.inCombat()) return false;
+    const party = me.currentParty;
+    if (!party) return false;
+    for (const pm of party.members) {
+      const u = objMgr.findObject(pm.guid);
+      if (u && u.deadOrGhost && me.distanceTo(u) <= 40) return true;
+    }
+    return false;
+  }
+
+  riptideTarget() {
+    for (const u of heal.priorityList) {
+      if (u.predictedHealthPercent <= Settings.ShamanRestoRiptideHP &&
+          !u.hasAuraByMe("Riptide")) {
+        return u;
+      }
+    }
+    return null;
+  }
+
+  healingWaveTarget() {
+    const t = heal.getPriorityTarget();
+    if (t && t.predictedHealthPercent <= Settings.ShamanRestoHealingWaveHP) return t;
+    return null;
+  }
+
+  chainHealTarget() {
+    let best = null;
+    let bestCount = 0;
+    for (const u of heal.priorityList) {
+      if (u.predictedHealthPercent > Settings.ShamanRestoChainHealHP) continue;
+      let count = 0;
+      for (const other of heal.priorityList) {
+        if (other.predictedHealthPercent <= Settings.ShamanRestoChainHealHP &&
+            u.distanceTo(other) <= 20) {
+          count++;
+        }
+      }
+      if (count > bestCount) {
+        best = u;
+        bestCount = count;
+      }
+    }
+    return bestCount >= Settings.ShamanRestoChainHealTargets ? best : null;
+  }
+
+  fillerDPS() {
+    return new bt.Decorator(
+      () => {
+        if (!Settings.ShamanRestoDPSFiller) return false;
+        if (!combat.bestTarget) return false;
+        for (const u of heal.priorityList) {
+          if (u.predictedHealthPercent < Settings.ShamanRestoDPSStopHP) return false;
+        }
+        return true;
+      },
+      new bt.Selector(
+        common.waitForFacing(),
+        spell.cast("Chain Lightning", on => combat.bestTarget, req => combat.targets.length >= 2),
+        spell.cast("Lightning Bolt", on => combat.bestTarget)
+      )
+    );
+  }
+}

--- a/Behaviors/rejiko/RestorationShaman.js
+++ b/Behaviors/rejiko/RestorationShaman.js
@@ -153,9 +153,25 @@ export class ShamanRestorationBehavior extends Behavior {
       },
       new bt.Selector(
         common.waitForFacing(),
-        spell.cast("Chain Lightning", on => combat.bestTarget, req => combat.targets.length >= 2),
+        spell.cast("Chain Lightning", on => this.chainLightningTarget()),
         spell.cast("Lightning Bolt", on => combat.bestTarget)
       )
     );
+  }
+
+  chainLightningTarget() {
+    let best = null;
+    let bestCount = 0;
+    for (const u of combat.targets) {
+      let count = 0;
+      for (const other of combat.targets) {
+        if (u.distanceTo(other) <= 10) count++;
+      }
+      if (count > bestCount) {
+        best = u;
+        bestCount = count;
+      }
+    }
+    return bestCount >= 2 ? best : null;
   }
 }


### PR DESCRIPTION
## Summary
- Adds a new author folder `Behaviors/rejiko/` alongside the existing `ejt/`, `jmr/`, `neer/`, `soviet/`, and `Nuclear/` folders
- 6 rotation profiles included: Initial Druid / Rogue / Shaman (low-level fillers), Outlaw Rogue, Restoration Druid, Restoration Shaman
- All rotations registered under `[Rejiko] <Spec> <Class>` naming so they group together in the rotation dropdown and don't collide with existing authors' profiles for the same specs

## Test plan
- [ ] Load each rotation in-game on a character of the corresponding spec
- [ ] Verify GUI setting panels render for each profile
- [ ] Smoke-test combat behavior (basic damage rotation, healing target selection, defensive triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)